### PR TITLE
parity daemonize fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,28 +1695,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2 1.0.58",
- "quote 1.0.27",
- "syn 1.0.94",
- "synstructure",
-]
-
-[[package]]
 name = "fake-fetch"
 version = "0.0.1"
 dependencies = [
@@ -3251,14 +3229,13 @@ dependencies = [
 [[package]]
 name = "parity-daemonize"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b1910b2793ff52713fca0a4ee92544ebec59ccd218ea74560be6f947b4ca77"
+source = "git+https://github.com/DMDcoin/parity-daemonize.git?rev=1d0802cd6880b0b914c6e82ba274bb3fc63238fb#1d0802cd6880b0b914c6e82ba274bb3fc63238fb"
 dependencies = [
  "ansi_term 0.11.0",
- "failure",
  "libc",
  "log",
  "mio",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ node-filter = { path = "crates/net/node-filter" }
 parity-crypto = { version = "0.6.2", features = [ "publickey" ] }
 rlp = { version = "0.4.6" }
 cli-signer= { path = "crates/util/cli-signer" }
-parity-daemonize = "0.3"
+parity-daemonize = { git = "https://github.com/DMDcoin/parity-daemonize.git", rev = "1d0802cd6880b0b914c6e82ba274bb3fc63238fb" }
 parity-local-store = { path = "crates/concensus/miner/local-store" }
 parity-runtime = { path = "crates/runtime/runtime" }
 parity-rpc = { path = "crates/rpc" }


### PR DESCRIPTION
Eliminates the "failure" crate completely from the diamond-node build.