### PR TITLE
Manually removed the "failure" dependency from the EIP-712 crate

### DIFF
--- a/crates/util/EIP-712/Cargo.lock
+++ b/crates/util/EIP-712/Cargo.lock
@@ -105,7 +105,6 @@ version = "0.1.0"
 dependencies = [
  "ethabi",
  "ethereum-types",
- "failure",
  "indexmap",
  "itertools",
  "keccak-hash",
@@ -165,28 +164,6 @@ dependencies = [
  "impl-serde",
  "primitive-types",
  "uint",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "syn 1.0.73",
- "synstructure",
 ]
 
 [[package]]


### PR DESCRIPTION
Hopefully fixes that sticky critical issue from the dependabot reports.