### PR TITLE
PR for Diamond Node Software 3.3.5-hbbft-0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 
+
+## Diamond Node Software 3.3.5-hbbft-0.9.6
+
+- [Early Epoch End: only report disconnectivities that exist for longer than 60 Minutes] (https://github.com/DMDcoin/diamond-node/issues/87)
+- [Improved Logging for Hbbft Session Management] (https://github.com/DMDcoin/diamond-node/issues/150)
+
+## Diamond Node Software 3.3.5-hbbft-0.9.5
+
+- [Improved Logging of ] (https://github.com/DMDcoin/diamond-node/issues/147)
+- [Early Epoch end: Applying new time based rules]  (https://github.com/DMDcoin/diamond-node/issues/87)
+
+
+
 ## Diamond Node Software 3.3.5-hbbft-0.9.5
 
 - [Improved Logging for Stage 5 Errors] (https://github.com/DMDcoin/diamond-node/issues/147)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "diamond-node"
-version = "3.3.5-hbbft-0.9.4"
+version = "3.3.5-hbbft-0.9.6"
 dependencies = [
  "ansi_term 0.10.2",
  "atty",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "3.3.5-hbbft-0.9.4"
+version = "3.3.5-hbbft-0.9.6"
 dependencies = [
  "parity-bytes",
  "rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Diamond Node"
 name = "diamond-node"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "3.3.5-hbbft-0.9.4"
+version = "3.3.5-hbbft-0.9.6"
 license = "GPL-3.0"
 authors = [
 	"bit.diamonds developers",

--- a/crates/ethcore/src/engines/hbbft/hbbft_early_epoch_end_manager.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_early_epoch_end_manager.rs
@@ -288,7 +288,12 @@ impl HbbftEarlyEpochEndManager {
         // todo: read this out from contracts: ConnectivityTrackerHbbft -> reportDisallowPeriod
         // requires us to update the Contracts ABIs:
         // https://github.com/DMDcoin/diamond-node/issues/115
-        let treshold_time = Duration::from_secs(60 * 15);
+        let treshold_time = Duration::from_secs(60 * 60);
+
+        if self.start_time.elapsed() < treshold_time {
+            debug!(target: "engine", "early-epoch-end: no decision: Treshold time not reached.");
+            return;
+        }
 
         if block_num < self.start_block + treshold {
             // not enought blocks have passed this epoch,

--- a/crates/ethcore/sync/src/api.rs
+++ b/crates/ethcore/sync/src/api.rs
@@ -696,7 +696,7 @@ impl ChainNotify for EthSync {
                     Some(session_info) => {
                         session_info.id == node_id
                     },
-                    None => { warn!(target:"sync", "No session exists for peerId {:?}", p); false},
+                    None => { warn!(target:"sync", "No session exists for peerId {:?} Node: {:?}", p, node_id); false},
                 }
             });
 

--- a/crates/util/version/Cargo.toml
+++ b/crates/util/version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for OpenEthereum version string (via env CARGO_PKG_VERSION)
-version = "3.3.5-hbbft-0.9.4"
+version = "3.3.5-hbbft-0.9.6"
 authors = [
 	"bit.diamonds developers",
 	"OpenEthereum developers",


### PR DESCRIPTION
## Diamond Node Software 3.3.5-hbbft-0.9.6
- [Early Epoch End: only report disconnectivities that exist for longer than 60 Minutes] (https://github.com/DMDcoin/diamond-node/issues/87)
- [Improved Logging for Hbbft Session Management] (https://github.com/DMDcoin/diamond-node/issues/150)

