### PR TITLE
Branding diamond node

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - dev
+      - beta
 jobs:
   build-tests:
     name:                       Test and Build

--- a/bin/oe/cli/mod.rs
+++ b/bin/oe/cli/mod.rs
@@ -1053,52 +1053,59 @@ mod tests {
         Account, Args, ArgsError, Config, Footprint, Ipc, Metrics, Mining, Misc, Network,
         Operating, Rpc, SecretStore, Snapshots, Ws,
     };
+    use crate::NODE_SOFTWARE_NAME;
     use clap::ErrorKind as ClapErrorKind;
     use toml;
 
     #[test]
     fn should_accept_any_argument_order() {
-        let args = Args::parse(&["openethereum", "--no-warp", "account", "list"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "--no-warp", "account", "list"]).unwrap();
         assert!(args.flag_no_warp);
 
-        let args = Args::parse(&["openethereum", "account", "list", "--no-warp"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "account", "list", "--no-warp"]).unwrap();
         assert!(args.flag_no_warp);
 
-        let args = Args::parse(&["openethereum", "--chain=dev", "account", "list"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "--chain=dev", "account", "list"]).unwrap();
         assert_eq!(args.arg_chain, "dev");
 
-        let args = Args::parse(&["openethereum", "account", "list", "--chain=dev"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "account", "list", "--chain=dev"]).unwrap();
         assert_eq!(args.arg_chain, "dev");
     }
 
     #[test]
     fn should_reject_invalid_values() {
-        let args = Args::parse(&["openethereum", "--jsonrpc-port=8545"]);
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "--jsonrpc-port=8545"]);
         assert!(args.is_ok());
 
-        let args = Args::parse(&["openethereum", "--jsonrpc-port=asd"]);
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "--jsonrpc-port=asd"]);
         assert!(args.is_err());
     }
 
     #[test]
     fn should_parse_args_and_flags() {
-        let args = Args::parse(&["openethereum", "--no-warp"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "--no-warp"]).unwrap();
         assert!(args.flag_no_warp);
 
-        let args = Args::parse(&["openethereum", "--pruning", "archive"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "--pruning", "archive"]).unwrap();
         assert_eq!(args.arg_pruning, "archive");
 
-        let args = Args::parse(&["openethereum", "export", "state", "--no-storage"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "export", "state", "--no-storage"]).unwrap();
         assert!(args.flag_export_state_no_storage);
 
-        let args =
-            Args::parse(&["openethereum", "export", "state", "--min-balance", "123"]).unwrap();
+        let args = Args::parse(&[
+            NODE_SOFTWARE_NAME,
+            "export",
+            "state",
+            "--min-balance",
+            "123",
+        ])
+        .unwrap();
         assert_eq!(args.arg_export_state_min_balance, Some("123".to_string()));
     }
 
     #[test]
     fn should_exit_gracefully_on_unknown_argument() {
-        let result = Args::parse(&["openethereum", "--please-exit-gracefully"]);
+        let result = Args::parse(&[NODE_SOFTWARE_NAME, "--please-exit-gracefully"]);
         assert!(match result {
             Err(ArgsError::Clap(ref clap_error))
                 if clap_error.kind == ClapErrorKind::UnknownArgument =>
@@ -1109,39 +1116,40 @@ mod tests {
 
     #[test]
     fn should_use_subcommand_arg_default() {
-        let args = Args::parse(&["openethereum", "export", "state", "--at", "123"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "export", "state", "--at", "123"]).unwrap();
         assert_eq!(args.arg_export_state_at, "123");
         assert_eq!(args.arg_snapshot_at, "latest");
 
-        let args = Args::parse(&["openethereum", "snapshot", "--at", "123", "file.dump"]).unwrap();
+        let args =
+            Args::parse(&[NODE_SOFTWARE_NAME, "snapshot", "--at", "123", "file.dump"]).unwrap();
         assert_eq!(args.arg_snapshot_at, "123");
         assert_eq!(args.arg_export_state_at, "latest");
 
-        let args = Args::parse(&["openethereum", "export", "state"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "export", "state"]).unwrap();
         assert_eq!(args.arg_snapshot_at, "latest");
         assert_eq!(args.arg_export_state_at, "latest");
 
-        let args = Args::parse(&["openethereum", "snapshot", "file.dump"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "snapshot", "file.dump"]).unwrap();
         assert_eq!(args.arg_snapshot_at, "latest");
         assert_eq!(args.arg_export_state_at, "latest");
     }
 
     #[test]
     fn should_parse_multiple_values() {
-        let args = Args::parse(&["openethereum", "account", "import", "~/1", "~/2"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "account", "import", "~/1", "~/2"]).unwrap();
         assert_eq!(
             args.arg_account_import_path,
             Some(vec!["~/1".to_owned(), "~/2".to_owned()])
         );
 
-        let args = Args::parse(&["openethereum", "account", "import", "~/1,ext"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "account", "import", "~/1,ext"]).unwrap();
         assert_eq!(
             args.arg_account_import_path,
             Some(vec!["~/1,ext".to_owned()])
         );
 
         let args = Args::parse(&[
-            "openethereum",
+            NODE_SOFTWARE_NAME,
             "--secretstore-nodes",
             "abc@127.0.0.1:3333,cde@10.10.10.10:4444",
         ])
@@ -1152,7 +1160,7 @@ mod tests {
         );
 
         let args = Args::parse(&[
-            "openethereum",
+            NODE_SOFTWARE_NAME,
             "--password",
             "~/.safe/1",
             "--password",
@@ -1164,7 +1172,7 @@ mod tests {
             vec!["~/.safe/1".to_owned(), "~/.safe/2".to_owned()]
         );
 
-        let args = Args::parse(&["openethereum", "--password", "~/.safe/1,~/.safe/2"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "--password", "~/.safe/1,~/.safe/2"]).unwrap();
         assert_eq!(
             args.arg_password,
             vec!["~/.safe/1".to_owned(), "~/.safe/2".to_owned()]
@@ -1173,7 +1181,7 @@ mod tests {
 
     #[test]
     fn should_parse_global_args_with_subcommand() {
-        let args = Args::parse(&["openethereum", "--chain", "dev", "account", "list"]).unwrap();
+        let args = Args::parse(&[NODE_SOFTWARE_NAME, "--chain", "dev", "account", "list"]).unwrap();
         assert_eq!(args.arg_chain, "dev".to_owned());
     }
 
@@ -1201,7 +1209,8 @@ mod tests {
         config.parity = Some(operating);
 
         // when
-        let args = Args::parse_with_config(&["openethereum", "--chain", "xyz"], config).unwrap();
+        let args =
+            Args::parse_with_config(&[NODE_SOFTWARE_NAME, "--chain", "xyz"], config).unwrap();
 
         // then
         assert_eq!(args.arg_chain, "xyz".to_owned());
@@ -1227,7 +1236,8 @@ mod tests {
         let config = toml::from_str(include_str!("./tests/config.full.toml")).unwrap();
 
         // when
-        let args = Args::parse_with_config(&["openethereum", "--chain", "xyz"], config).unwrap();
+        let args =
+            Args::parse_with_config(&[NODE_SOFTWARE_NAME, "--chain", "xyz"], config).unwrap();
 
         // then
         assert_eq!(
@@ -1656,7 +1666,7 @@ mod tests {
 
     #[test]
     fn should_not_accept_min_peers_bigger_than_max_peers() {
-        match Args::parse(&["openethereum", "--max-peers=39", "--min-peers=40"]) {
+        match Args::parse(&[NODE_SOFTWARE_NAME, "--max-peers=39", "--min-peers=40"]) {
             Err(ArgsError::PeerConfiguration) => (),
             _ => assert_eq!(false, true),
         }
@@ -1664,7 +1674,7 @@ mod tests {
 
     #[test]
     fn should_accept_max_peers_equal_or_bigger_than_min_peers() {
-        Args::parse(&["openethereum", "--max-peers=40", "--min-peers=40"]).unwrap();
-        Args::parse(&["openethereum", "--max-peers=100", "--min-peers=40"]).unwrap();
+        Args::parse(&[NODE_SOFTWARE_NAME, "--max-peers=40", "--min-peers=40"]).unwrap();
+        Args::parse(&[NODE_SOFTWARE_NAME, "--max-peers=100", "--min-peers=40"]).unwrap();
     }
 }

--- a/bin/oe/configuration.rs
+++ b/bin/oe/configuration.rs
@@ -1277,6 +1277,8 @@ mod tests {
 
     use super::*;
 
+    use crate::NODE_SOFTWARE_NAME;
+
     lazy_static! {
         static ref ITERATIONS: NonZeroU32 = NonZeroU32::new(10240).expect("10240 > 0; qed");
     }
@@ -1289,14 +1291,14 @@ mod tests {
 
     #[test]
     fn test_command_version() {
-        let args = vec!["openethereum", "--version"];
+        let args = vec![NODE_SOFTWARE_NAME, "--version"];
         let conf = parse(&args);
         assert_eq!(conf.into_command().unwrap().cmd, Cmd::Version);
     }
 
     #[test]
     fn test_command_account_new() {
-        let args = vec!["openethereum", "account", "new"];
+        let args = vec![NODE_SOFTWARE_NAME, "account", "new"];
         let conf = parse(&args);
         assert_eq!(
             conf.into_command().unwrap().cmd,
@@ -1311,7 +1313,7 @@ mod tests {
 
     #[test]
     fn test_command_account_list() {
-        let args = vec!["openethereum", "account", "list"];
+        let args = vec![NODE_SOFTWARE_NAME, "account", "list"];
         let conf = parse(&args);
         assert_eq!(
             conf.into_command().unwrap().cmd,
@@ -1324,7 +1326,13 @@ mod tests {
 
     #[test]
     fn test_command_account_import() {
-        let args = vec!["openethereum", "account", "import", "my_dir", "another_dir"];
+        let args = vec![
+            NODE_SOFTWARE_NAME,
+            "account",
+            "import",
+            "my_dir",
+            "another_dir",
+        ];
         let conf = parse(&args);
         assert_eq!(
             conf.into_command().unwrap().cmd,
@@ -1339,7 +1347,7 @@ mod tests {
     #[test]
     fn test_command_wallet_import() {
         let args = vec![
-            "openethereum",
+            NODE_SOFTWARE_NAME,
             "wallet",
             "import",
             "my_wallet.json",
@@ -1361,7 +1369,7 @@ mod tests {
 
     #[test]
     fn test_command_blockchain_import() {
-        let args = vec!["openethereum", "import", "blockchain.json"];
+        let args = vec![NODE_SOFTWARE_NAME, "import", "blockchain.json"];
         let conf = parse(&args);
         assert_eq!(
             conf.into_command().unwrap().cmd,
@@ -1388,7 +1396,7 @@ mod tests {
 
     #[test]
     fn test_command_blockchain_export() {
-        let args = vec!["openethereum", "export", "blocks", "blockchain.json"];
+        let args = vec![NODE_SOFTWARE_NAME, "export", "blocks", "blockchain.json"];
         let conf = parse(&args);
         assert_eq!(
             conf.into_command().unwrap().cmd,
@@ -1414,7 +1422,7 @@ mod tests {
 
     #[test]
     fn test_command_state_export() {
-        let args = vec!["openethereum", "export", "state", "state.json"];
+        let args = vec![NODE_SOFTWARE_NAME, "export", "state", "state.json"];
         let conf = parse(&args);
         assert_eq!(
             conf.into_command().unwrap().cmd,
@@ -1443,7 +1451,7 @@ mod tests {
     #[test]
     fn test_command_blockchain_export_with_custom_format() {
         let args = vec![
-            "openethereum",
+            NODE_SOFTWARE_NAME,
             "export",
             "blocks",
             "--format",
@@ -1475,7 +1483,7 @@ mod tests {
 
     #[test]
     fn test_command_signer_new_token() {
-        let args = vec!["openethereum", "signer", "new-token"];
+        let args = vec![NODE_SOFTWARE_NAME, "signer", "new-token"];
         let conf = parse(&args);
         let expected = Directories::default().signer;
         assert_eq!(
@@ -1508,7 +1516,7 @@ mod tests {
 
     #[test]
     fn test_ws_max_connections() {
-        let args = vec!["openethereum", "--ws-max-connections", "1"];
+        let args = vec![NODE_SOFTWARE_NAME, "--ws-max-connections", "1"];
         let conf = parse(&args);
 
         assert_eq!(
@@ -1580,7 +1588,7 @@ mod tests {
 
         // when
         let conf0 = parse(&["openethereum"]);
-        let conf2 = parse(&["openethereum", "--tx-queue-strategy", "gas_price"]);
+        let conf2 = parse(&[NODE_SOFTWARE_NAME, "--tx-queue-strategy", "gas_price"]);
 
         // then
         assert_eq!(conf0.miner_options().unwrap(), mining_options);
@@ -1591,7 +1599,7 @@ mod tests {
     #[test]
     fn should_fail_on_force_reseal_and_reseal_min_period() {
         let conf = parse(&[
-            "openethereum",
+            NODE_SOFTWARE_NAME,
             "--chain",
             "dev",
             "--force-sealing",
@@ -1608,7 +1616,7 @@ mod tests {
 
         // when
         let conf = parse(&[
-            "openethereum",
+            NODE_SOFTWARE_NAME,
             "--chain",
             "goerli",
             "--identity",
@@ -1636,9 +1644,13 @@ mod tests {
 
         // when
         let conf0 = parse(&["openethereum"]);
-        let conf1 = parse(&["openethereum", "--jsonrpc-hosts", "none"]);
-        let conf2 = parse(&["openethereum", "--jsonrpc-hosts", "all"]);
-        let conf3 = parse(&["openethereum", "--jsonrpc-hosts", "parity.io,something.io"]);
+        let conf1 = parse(&[NODE_SOFTWARE_NAME, "--jsonrpc-hosts", "none"]);
+        let conf2 = parse(&[NODE_SOFTWARE_NAME, "--jsonrpc-hosts", "all"]);
+        let conf3 = parse(&[
+            NODE_SOFTWARE_NAME,
+            "--jsonrpc-hosts",
+            "parity.io,something.io",
+        ]);
 
         // then
         assert_eq!(conf0.rpc_hosts(), Some(Vec::new()));
@@ -1655,7 +1667,7 @@ mod tests {
         // given
 
         // when
-        let conf0 = parse(&["openethereum", "--ui-path=signer"]);
+        let conf0 = parse(&[NODE_SOFTWARE_NAME, "--ui-path=signer"]);
 
         // then
         assert_eq!(conf0.directories().signer, "signer".to_owned());
@@ -1670,7 +1682,7 @@ mod tests {
             .write_all(b"  \n\t\n")
             .unwrap();
         let args = vec![
-            "openethereum",
+            NODE_SOFTWARE_NAME,
             "--reserved-peers",
             filename.to_str().unwrap(),
         ];
@@ -1684,7 +1696,7 @@ mod tests {
         let filename = tempdir.path().join("peers_comments");
         File::create(&filename).unwrap().write_all(b"# Sample comment\nenode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@172.0.0.1:30303\n").unwrap();
         let args = vec![
-            "openethereum",
+            NODE_SOFTWARE_NAME,
             "--reserved-peers",
             filename.to_str().unwrap(),
         ];
@@ -1696,7 +1708,7 @@ mod tests {
 
     #[test]
     fn test_dev_preset() {
-        let args = vec!["openethereum", "--config", "dev"];
+        let args = vec![NODE_SOFTWARE_NAME, "--config", "dev"];
         let conf = Configuration::parse_cli(&args).unwrap();
         match conf.into_command().unwrap().cmd {
             Cmd::Run(c) => {
@@ -1710,7 +1722,7 @@ mod tests {
 
     #[test]
     fn test_mining_preset() {
-        let args = vec!["openethereum", "--config", "mining"];
+        let args = vec![NODE_SOFTWARE_NAME, "--config", "mining"];
         let conf = Configuration::parse_cli(&args).unwrap();
         match conf.into_command().unwrap().cmd {
             Cmd::Run(c) => {
@@ -1734,7 +1746,7 @@ mod tests {
 
     #[test]
     fn test_non_standard_ports_preset() {
-        let args = vec!["openethereum", "--config", "non-standard-ports"];
+        let args = vec![NODE_SOFTWARE_NAME, "--config", "non-standard-ports"];
         let conf = Configuration::parse_cli(&args).unwrap();
         match conf.into_command().unwrap().cmd {
             Cmd::Run(c) => {
@@ -1747,7 +1759,7 @@ mod tests {
 
     #[test]
     fn test_insecure_preset() {
-        let args = vec!["openethereum", "--config", "insecure"];
+        let args = vec![NODE_SOFTWARE_NAME, "--config", "insecure"];
         let conf = Configuration::parse_cli(&args).unwrap();
         match conf.into_command().unwrap().cmd {
             Cmd::Run(c) => {
@@ -1765,7 +1777,7 @@ mod tests {
 
     #[test]
     fn test_dev_insecure_preset() {
-        let args = vec!["openethereum", "--config", "dev-insecure"];
+        let args = vec![NODE_SOFTWARE_NAME, "--config", "dev-insecure"];
         let conf = Configuration::parse_cli(&args).unwrap();
         match conf.into_command().unwrap().cmd {
             Cmd::Run(c) => {
@@ -1786,7 +1798,7 @@ mod tests {
 
     #[test]
     fn test_override_preset() {
-        let args = vec!["openethereum", "--config", "mining", "--min-peers=99"];
+        let args = vec![NODE_SOFTWARE_NAME, "--config", "mining", "--min-peers=99"];
         let conf = Configuration::parse_cli(&args).unwrap();
         match conf.into_command().unwrap().cmd {
             Cmd::Run(c) => {
@@ -1798,7 +1810,7 @@ mod tests {
 
     #[test]
     fn test_identity_arg() {
-        let args = vec!["openethereum", "--identity", "Somebody"];
+        let args = vec![NODE_SOFTWARE_NAME, "--identity", "Somebody"];
         let conf = Configuration::parse_cli(&args).unwrap();
         match conf.into_command().unwrap().cmd {
             Cmd::Run(c) => {
@@ -1817,9 +1829,9 @@ mod tests {
         // given
 
         // when
-        let conf0 = parse(&["openethereum", "--ports-shift", "1", "--stratum"]);
+        let conf0 = parse(&[NODE_SOFTWARE_NAME, "--ports-shift", "1", "--stratum"]);
         let conf1 = parse(&[
-            "openethereum",
+            NODE_SOFTWARE_NAME,
             "--ports-shift",
             "1",
             "--jsonrpc-port",
@@ -1848,7 +1860,7 @@ mod tests {
     #[test]
     fn should_resolve_external_nat_hosts() {
         // Ip works
-        let conf = parse(&["openethereum", "--nat", "extip:1.1.1.1"]);
+        let conf = parse(&[NODE_SOFTWARE_NAME, "--nat", "extip:1.1.1.1"]);
         assert_eq!(
             conf.net_addresses().unwrap().1.unwrap().ip().to_string(),
             "1.1.1.1"
@@ -1856,7 +1868,7 @@ mod tests {
         assert_eq!(conf.net_addresses().unwrap().1.unwrap().port(), 30303);
 
         // Ip with port works, port is discarded
-        let conf = parse(&["openethereum", "--nat", "extip:192.168.1.1:123"]);
+        let conf = parse(&[NODE_SOFTWARE_NAME, "--nat", "extip:192.168.1.1:123"]);
         assert_eq!(
             conf.net_addresses().unwrap().1.unwrap().ip().to_string(),
             "192.168.1.1"
@@ -1864,13 +1876,13 @@ mod tests {
         assert_eq!(conf.net_addresses().unwrap().1.unwrap().port(), 30303);
 
         // Hostname works
-        let conf = parse(&["openethereum", "--nat", "extip:ethereum.org"]);
+        let conf = parse(&[NODE_SOFTWARE_NAME, "--nat", "extip:ethereum.org"]);
         assert!(conf.net_addresses().unwrap().1.is_some());
         assert_eq!(conf.net_addresses().unwrap().1.unwrap().port(), 30303);
 
         // Hostname works, garbage at the end is discarded
         let conf = parse(&[
-            "openethereum",
+            NODE_SOFTWARE_NAME,
             "--nat",
             "extip:ethereum.org:whatever bla bla 123",
         ]);
@@ -1878,7 +1890,7 @@ mod tests {
         assert_eq!(conf.net_addresses().unwrap().1.unwrap().port(), 30303);
 
         // Garbage is error
-        let conf = parse(&["openethereum", "--nat", "extip:blabla"]);
+        let conf = parse(&[NODE_SOFTWARE_NAME, "--nat", "extip:blabla"]);
         assert!(conf.net_addresses().is_err());
     }
 
@@ -1887,7 +1899,7 @@ mod tests {
         // given
 
         // when
-        let conf0 = parse(&["openethereum", "--unsafe-expose"]);
+        let conf0 = parse(&[NODE_SOFTWARE_NAME, "--unsafe-expose"]);
 
         // then
         assert_eq!(&conf0.network_settings().unwrap().rpc_interface, "0.0.0.0");
@@ -1905,16 +1917,16 @@ mod tests {
 
     #[test]
     fn allow_ips() {
-        let all = parse(&["openethereum", "--allow-ips", "all"]);
-        let private = parse(&["openethereum", "--allow-ips", "private"]);
-        let block_custom = parse(&["openethereum", "--allow-ips", "-10.0.0.0/8"]);
+        let all = parse(&[NODE_SOFTWARE_NAME, "--allow-ips", "all"]);
+        let private = parse(&[NODE_SOFTWARE_NAME, "--allow-ips", "private"]);
+        let block_custom = parse(&[NODE_SOFTWARE_NAME, "--allow-ips", "-10.0.0.0/8"]);
         let combo = parse(&[
-            "openethereum",
+            NODE_SOFTWARE_NAME,
             "--allow-ips",
             "public 10.0.0.0/8 -1.0.0.0/8",
         ]);
-        let ipv6_custom_public = parse(&["openethereum", "--allow-ips", "public fc00::/7"]);
-        let ipv6_custom_private = parse(&["openethereum", "--allow-ips", "private -fc00::/7"]);
+        let ipv6_custom_public = parse(&[NODE_SOFTWARE_NAME, "--allow-ips", "public fc00::/7"]);
+        let ipv6_custom_private = parse(&[NODE_SOFTWARE_NAME, "--allow-ips", "private -fc00::/7"]);
 
         assert_eq!(
             all.ip_filter().unwrap(),
@@ -1976,7 +1988,7 @@ mod tests {
         use std::path;
 
         let std = parse(&["openethereum"]);
-        let base = parse(&["openethereum", "--base-path", "/test"]);
+        let base = parse(&[NODE_SOFTWARE_NAME, "--base-path", "/test"]);
 
         let base_path = ::dir::default_data_path();
         let local_path = ::dir::default_local_path();
@@ -1992,7 +2004,7 @@ mod tests {
 
     #[test]
     fn should_respect_only_max_peers_and_default() {
-        let args = vec!["openethereum", "--max-peers=50"];
+        let args = vec![NODE_SOFTWARE_NAME, "--max-peers=50"];
         let conf = Configuration::parse_cli(&args).unwrap();
         match conf.into_command().unwrap().cmd {
             Cmd::Run(c) => {
@@ -2005,7 +2017,7 @@ mod tests {
 
     #[test]
     fn should_respect_only_max_peers_less_than_default() {
-        let args = vec!["openethereum", "--max-peers=5"];
+        let args = vec![NODE_SOFTWARE_NAME, "--max-peers=5"];
         let conf = Configuration::parse_cli(&args).unwrap();
         match conf.into_command().unwrap().cmd {
             Cmd::Run(c) => {
@@ -2018,7 +2030,7 @@ mod tests {
 
     #[test]
     fn should_respect_only_min_peers_and_default() {
-        let args = vec!["openethereum", "--min-peers=5"];
+        let args = vec![NODE_SOFTWARE_NAME, "--min-peers=5"];
         let conf = Configuration::parse_cli(&args).unwrap();
         match conf.into_command().unwrap().cmd {
             Cmd::Run(c) => {
@@ -2031,7 +2043,7 @@ mod tests {
 
     #[test]
     fn should_respect_only_min_peers_and_greater_than_default() {
-        let args = vec!["openethereum", "--min-peers=500"];
+        let args = vec![NODE_SOFTWARE_NAME, "--min-peers=500"];
         let conf = Configuration::parse_cli(&args).unwrap();
         match conf.into_command().unwrap().cmd {
             Cmd::Run(c) => {
@@ -2044,7 +2056,10 @@ mod tests {
 
     #[test]
     fn should_parse_shutdown_on_missing_block_import() {
-        let args = vec!["openethereum", "--shutdown-on-missing-block-import=1234"];
+        let args = vec![
+            NODE_SOFTWARE_NAME,
+            "--shutdown-on-missing-block-import=1234",
+        ];
         let conf = Configuration::parse_cli(&args).unwrap();
         match conf.into_command().unwrap().cmd {
             Cmd::Run(c) => {

--- a/bin/oe/lib.rs
+++ b/bin/oe/lib.rs
@@ -135,6 +135,9 @@ pub use parity_rpc::PubSubSession;
 #[global_allocator]
 static A: System = System;
 
+/// The name of the node software.
+pub const NODE_SOFTWARE_NAME: &str = "diamond-node";
+
 fn print_hash_of(maybe_file: Option<String>) -> Result<String, String> {
     if let Some(file) = maybe_file {
         let mut f =

--- a/crates/ethcore/sync/src/chain/propagator.rs
+++ b/crates/ethcore/sync/src/chain/propagator.rs
@@ -233,7 +233,10 @@ impl ChainSync {
                 .expect("peer_id is form peers; peers is result of select_peers_for_transactions; select_peers_for_transactions selects peers from self.peers; qed");
 
             let (id, is_hashes) = if let Some(session_info) = io.peer_session_info(peer_id) {
-                (session_info.id, session_info.is_pooled_transactions_capable())
+                (
+                    session_info.id,
+                    session_info.is_pooled_transactions_capable(),
+                )
             } else {
                 warn!(target: "sync", "no peer session info available: could not detect if peer is capable of eip-2464 transaction gossiping");
                 continue;

--- a/crates/ethcore/sync/src/chain/propagator.rs
+++ b/crates/ethcore/sync/src/chain/propagator.rs
@@ -232,16 +232,12 @@ impl ChainSync {
             let peer_info = self.peers.get_mut(&peer_id)
                 .expect("peer_id is form peers; peers is result of select_peers_for_transactions; select_peers_for_transactions selects peers from self.peers; qed");
 
-            let mut id: Option<ethereum_types::H512> = None;
-            let mut is_hashes = false;
-
-            if let Some(session_info) = io.peer_session_info(peer_id) {
-                is_hashes = session_info.is_pooled_transactions_capable();
-                id = session_info.id;
+            let (id, is_hashes) = if let Some(session_info) = io.peer_session_info(peer_id) {
+                (session_info.id, session_info.is_pooled_transactions_capable())
             } else {
                 warn!(target: "sync", "no peer session info available: could not detect if peer is capable of eip-2464 transaction gossiping");
                 continue;
-            }
+            };
 
             // Send all transactions, if the peer doesn't know about anything
             if peer_info.last_sent_transactions.is_empty() {


### PR DESCRIPTION
This pull request includes changes to the build configuration and improvements to the `ChainSync` implementation in the Ethereum core sync module. The most important changes involve adding a new branch to the build workflow and refactoring the peer session information handling.
 
### diamond-node Branding

Further steps for consistently using diamond-node as software name, instead of openethereum.
made it easier to change the software name by defining a constant.
 
### Build Configuration:

* [`.github/workflows/build-test.yml`](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32R9): Added the `beta` branch to the list of branches that trigger the build and test workflow.

### Code Refactoring:

* [`crates/ethcore/sync/src/chain/propagator.rs`](diffhunk://#diff-8aad484970f448e26b4f0cda2960d9e54208608e7e68482d66bbc632f279c83fL235-R243): Refactored the handling of peer session information by combining multiple variables into a single tuple, simplifying the code and improving readability.