### PR TITLE
Prep release 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "diamond-node"
-version = "3.3.5-hbbft-0.10.0"
+version = "3.3.5-hbbft-0.11.0-rc1"
 dependencies = [
  "ansi_term 0.10.2",
  "atty",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "3.3.5-hbbft-0.10.0"
+version = "3.3.5-hbbft-0.11.0-rc1"
 dependencies = [
  "parity-bytes",
  "rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Diamond Node"
 name = "diamond-node"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "3.3.5-hbbft-0.10.0"
+version = "3.3.5-hbbft-0.11.0-rc1"
 license = "GPL-3.0"
 authors = [
 	"bit.diamonds developers",

--- a/crates/ethcore/sync/src/chain/mod.rs
+++ b/crates/ethcore/sync/src/chain/mod.rs
@@ -107,7 +107,6 @@ use api::{EthProtocolInfo as PeerInfoDigest, PriorityTask, ETH_PROTOCOL, PAR_PRO
 use block_sync::{BlockDownloader, DownloadAction};
 use bytes::Bytes;
 use derive_more::Display;
-use env_logger::Target;
 use ethcore::{
     client::{BlockChainClient, BlockChainInfo, BlockId, BlockQueueInfo, BlockStatus},
     snapshot::RestorationStatus,

--- a/crates/ethcore/sync/src/chain/mod.rs
+++ b/crates/ethcore/sync/src/chain/mod.rs
@@ -1247,7 +1247,7 @@ impl ChainSync {
 
     /// Find something to do for a peer. Called for a new peer or when a peer is done with its task.
     fn sync_peer(&mut self, io: &mut dyn SyncIo, peer_id: PeerId, force: bool) {
-        info!(
+        debug!(
             "sync_peer: {} force {} state: {:?}",
             peer_id, force, self.state
         );

--- a/crates/ethcore/sync/src/chain/propagator.rs
+++ b/crates/ethcore/sync/src/chain/propagator.rs
@@ -187,9 +187,8 @@ impl ChainSync {
                 .retain_pending(&all_transactions_hashes);
         }
 
-        info!(target: "sync", "Propagating {} transactions to {} peers", transactions.len(), peers.len());
-
-        info!(target: "sync", "Propagating {:?}", all_transactions_hashes);
+        debug!(target: "sync", "Propagating {:?}", all_transactions_hashes);
+        trace!(target: "sync", "Propagating {} transactions to {} peers", transactions.len(), peers.len());
 
         let send_packet = |io: &mut dyn SyncIo,
                            stats: &mut SyncPropagatorStatistics,

--- a/crates/util/version/Cargo.toml
+++ b/crates/util/version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for OpenEthereum version string (via env CARGO_PKG_VERSION)
-version = "3.3.5-hbbft-0.10.0"
+version = "3.3.5-hbbft-0.11.0-rc1"
 authors = [
 	"bit.diamonds developers",
 	"OpenEthereum developers",


### PR DESCRIPTION
This pull request includes several changes to the `diamond-node` project, primarily focusing on updating dependencies and adjusting logging levels for better debugging and traceability. The most important changes include updating the version in `Cargo.toml` files and modifying logging levels in the `ChainSync` implementation.

### Dependency Updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L5-R5): Updated the version from `3.3.5-hbbft-0.10.0` to `3.3.5-hbbft-0.11.0-rc1`.
* [`crates/util/version/Cargo.toml`](diffhunk://#diff-8499406efaed86af552059ec236a42e8be6cec7b46dbd0906a5fd62fa26f2624L4-R4): Updated the version from `3.3.5-hbbft-0.10.0` to `3.3.5-hbbft-0.11.0-rc1`.

### Logging Level Adjustments:
* [`crates/ethcore/sync/src/chain/mod.rs`](diffhunk://#diff-e4d6d81b57d185f9c2c06099c864cef72115ad2110869556c0e471a64c82e607L935-R937): Changed various logging levels from `info` to `debug` or `trace` to reduce verbosity and improve debugging precision. [[1]](diffhunk://#diff-e4d6d81b57d185f9c2c06099c864cef72115ad2110869556c0e471a64c82e607L935-R937) [[2]](diffhunk://#diff-e4d6d81b57d185f9c2c06099c864cef72115ad2110869556c0e471a64c82e607L1250-R1251) [[3]](diffhunk://#diff-e4d6d81b57d185f9c2c06099c864cef72115ad2110869556c0e471a64c82e607L1291-R1297) [[4]](diffhunk://#diff-e4d6d81b57d185f9c2c06099c864cef72115ad2110869556c0e471a64c82e607L1487-R1463) [[5]](diffhunk://#diff-e4d6d81b57d185f9c2c06099c864cef72115ad2110869556c0e471a64c82e607L1496-R1472) [[6]](diffhunk://#diff-e4d6d81b57d185f9c2c06099c864cef72115ad2110869556c0e471a64c82e607L1505-R1481)
* [`crates/ethcore/sync/src/chain/propagator.rs`](diffhunk://#diff-8aad484970f448e26b4f0cda2960d9e54208608e7e68482d66bbc632f279c83fL190-R191): Adjusted logging levels from `info` to `debug` and `trace` for transaction propagation messages.

