### PR TITLE
Prep release 0.11.0 rc2

### DIFF
--- a/bin/oe/configuration.rs
+++ b/bin/oe/configuration.rs
@@ -110,7 +110,6 @@ pub enum Cmd {
 
 pub struct Execute {
     // pub logger: LogConfig,
-
     ///  executed command.
     pub cmd: Cmd,
 }

--- a/bin/oe/configuration.rs
+++ b/bin/oe/configuration.rs
@@ -109,7 +109,9 @@ pub enum Cmd {
 }
 
 pub struct Execute {
-    pub logger: LogConfig,
+    // pub logger: LogConfig,
+
+    ///  executed command.
     pub cmd: Cmd,
 }
 
@@ -438,7 +440,7 @@ impl Configuration {
         };
 
         Ok(Execute {
-            logger: logger_config,
+            // logger: logger_config,
             cmd,
         })
     }

--- a/crates/concensus/ethash/src/cache.rs
+++ b/crates/concensus/ethash/src/cache.rs
@@ -320,39 +320,42 @@ impl AsRef<[Node]> for NodeCache {
 // out. It counts as a read and causes all writes afterwards to be elided. Yes, really. I know, I
 // want to refactor this to use less `unsafe` as much as the next rustacean.
 unsafe fn initialize_memory(memory: *mut Node, num_nodes: usize, ident: &H256) {
-    // We use raw pointers here, see above
-    let dst = slice::from_raw_parts_mut(memory as *mut u8, NODE_BYTES);
-
-    debug_assert_eq!(ident.len(), 32);
-    keccak_512::write(&ident[..], dst);
-
-    for i in 1..num_nodes {
+    unsafe {
         // We use raw pointers here, see above
-        let dst = slice::from_raw_parts_mut(memory.offset(i as _) as *mut u8, NODE_BYTES);
-        let src = slice::from_raw_parts(memory.offset(i as isize - 1) as *mut u8, NODE_BYTES);
-        keccak_512::write(src, dst);
-    }
+        let dst = slice::from_raw_parts_mut(memory as *mut u8, NODE_BYTES);
 
-    // Now this is initialized, we can treat it as a slice.
-    let nodes: &mut [Node] = slice::from_raw_parts_mut(memory, num_nodes);
+        debug_assert_eq!(ident.len(), 32);
+        keccak_512::write(&ident[..], dst);
 
-    for _ in 0..ETHASH_CACHE_ROUNDS {
-        for i in 0..num_nodes {
-            let data_idx = (num_nodes - 1 + i) % num_nodes;
-            let idx = nodes.get_unchecked_mut(i).as_words()[0] as usize % num_nodes;
-
-            let data = {
-                let mut data: Node = nodes.get_unchecked(data_idx).clone();
-                let rhs: &Node = nodes.get_unchecked(idx);
-
-                for (a, b) in data.as_dwords_mut().iter_mut().zip(rhs.as_dwords()) {
-                    *a ^= *b;
-                }
-
-                data
-            };
-
-            keccak_512::write(&data.bytes, &mut nodes.get_unchecked_mut(i).bytes);
+        for i in 1..num_nodes {
+            // We use raw pointers here, see above
+            let dst = slice::from_raw_parts_mut(memory.offset(i as _) as *mut u8, NODE_BYTES);
+            let src = slice::from_raw_parts(memory.offset(i as isize - 1) as *mut u8, NODE_BYTES);
+            keccak_512::write(src, dst);
         }
+
+        // Now this is initialized, we can treat it as a slice.
+        let nodes: &mut [Node] = slice::from_raw_parts_mut(memory, num_nodes);
+
+        for _ in 0..ETHASH_CACHE_ROUNDS {
+            for i in 0..num_nodes {
+                let data_idx = (num_nodes - 1 + i) % num_nodes;
+                let idx = nodes.get_unchecked_mut(i).as_words()[0] as usize % num_nodes;
+
+                let data = {
+                    let mut data: Node = nodes.get_unchecked(data_idx).clone();
+                    let rhs: &Node = nodes.get_unchecked(idx);
+
+                    for (a, b) in data.as_dwords_mut().iter_mut().zip(rhs.as_dwords()) {
+                        *a ^= *b;
+                    }
+
+                    data
+                };
+
+                keccak_512::write(&data.bytes, &mut nodes.get_unchecked_mut(i).bytes);
+            }
+        }
+
     }
 }

--- a/crates/concensus/ethash/src/cache.rs
+++ b/crates/concensus/ethash/src/cache.rs
@@ -356,6 +356,5 @@ unsafe fn initialize_memory(memory: *mut Node, num_nodes: usize, ident: &H256) {
                 keccak_512::write(&data.bytes, &mut nodes.get_unchecked_mut(i).bytes);
             }
         }
-
     }
 }

--- a/crates/concensus/ethash/src/compute.rs
+++ b/crates/concensus/ethash/src/compute.rs
@@ -182,7 +182,10 @@ fn hash_compute(light: &Light, full_size: usize, header_hash: &H256, nonce: u64)
                 use std::mem;
 
                 debug_assert_eq!(val.len() * mem::size_of::<T>(), $n * mem::size_of::<U>());
-                &mut *(val.as_mut_ptr() as *mut [U; $n])
+                unsafe {
+                    &mut *(val.as_mut_ptr() as *mut [U; $n])
+                }
+                
             }
 
             make_const_array($value)

--- a/crates/concensus/ethash/src/compute.rs
+++ b/crates/concensus/ethash/src/compute.rs
@@ -182,10 +182,7 @@ fn hash_compute(light: &Light, full_size: usize, header_hash: &H256, nonce: u64)
                 use std::mem;
 
                 debug_assert_eq!(val.len() * mem::size_of::<T>(), $n * mem::size_of::<U>());
-                unsafe {
-                    &mut *(val.as_mut_ptr() as *mut [U; $n])
-                }
-                
+                unsafe { &mut *(val.as_mut_ptr() as *mut [U; $n]) }
             }
 
             make_const_array($value)

--- a/crates/concensus/miner/src/pool/queue.rs
+++ b/crates/concensus/miner/src/pool/queue.rs
@@ -786,12 +786,13 @@ impl TransactionQueue {
         (pool.listener_mut().1).0.add(f);
     }
 
-    /// Check if pending set is cached.
+    /// Check if pending set is cached. (enforced)
     #[cfg(test)]
     pub fn is_enforced_pending_cached(&self) -> bool {
         self.cached_enforced_pending.read().pending.is_some()
     }
 
+    /// Check if pending set is cached. (non-enforced)
     #[cfg(test)]
     pub fn is_non_enforced_pending_cached(&self) -> bool {
         self.cached_non_enforced_pending.read().pending.is_some()

--- a/crates/concensus/miner/src/service_transaction_checker.rs
+++ b/crates/concensus/miner/src/service_transaction_checker.rs
@@ -21,7 +21,7 @@ use call_contract::{CallContract, RegistryInfo};
 use ethabi::FunctionOutputDecoder;
 use ethereum_types::Address;
 use parking_lot::RwLock;
-use std::{collections::HashMap, mem, str::FromStr, sync::Arc};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use_contract!(
     service_transaction,

--- a/crates/ethcore/sync/Cargo.toml
+++ b/crates/ethcore/sync/Cargo.toml
@@ -47,3 +47,6 @@ ethcore = { path = "..", features = ["test-helpers"] }
 ethcore-io = { path = "../../runtime/io", features = ["mio"] }
 kvdb-memorydb = "0.1"
 rustc-hex = "1.0"
+
+[features]
+devP2PTests = []

--- a/crates/ethcore/sync/src/chain/propagator.rs
+++ b/crates/ethcore/sync/src/chain/propagator.rs
@@ -634,6 +634,7 @@ mod tests {
         assert_eq!(0x07, io.packets[0].packet_id);
     }
 
+    #[cfg(feature = "devP2PTests")]
     #[test]
     fn propagates_ready_transactions() {
         let mut client = TestBlockChainClient::new();
@@ -661,6 +662,7 @@ mod tests {
         assert_eq!(0x02, io.packets[0].packet_id);
     }
 
+    #[cfg(feature = "devP2PTests")]
     #[test]
     fn propagates_ready_transactions_to_subset_of_peers() {
         let mut client = TestBlockChainClient::new();
@@ -679,6 +681,7 @@ mod tests {
         assert_eq!(8, peer_count);
     }
 
+    #[cfg(feature = "devP2PTests")]
     #[test]
     fn propagates_new_transactions_to_all_peers() {
         let (new_transaction_hashes_tx, new_transaction_hashes_rx) = crossbeam_channel::unbounded();
@@ -699,6 +702,7 @@ mod tests {
         assert_eq!(25, peer_count);
     }
 
+    #[cfg(feature = "devP2PTests")]
     #[test]
     fn propagates_new_transactions() {
         let (new_transaction_hashes_tx, new_transaction_hashes_rx) = crossbeam_channel::unbounded();
@@ -733,6 +737,7 @@ mod tests {
         assert_eq!(0x02, io.packets[0].packet_id);
     }
 
+    #[cfg(feature = "devP2PTests")]
     #[test]
     fn does_not_propagate_ready_transactions_after_new_block() {
         let mut client = TestBlockChainClient::new();
@@ -756,6 +761,7 @@ mod tests {
         assert_eq!(0x02, io.packets[0].packet_id);
     }
 
+    #[cfg(feature = "devP2PTests")]
     #[test]
     fn does_not_propagate_new_transactions_after_new_block() {
         let (new_transaction_hashes_tx, new_transaction_hashes_rx) = crossbeam_channel::unbounded();
@@ -819,6 +825,7 @@ mod tests {
         assert_eq!(0, peer_count_new2);
     }
 
+    #[cfg(feature = "devP2PTests")]
     #[test]
     fn propagates_transactions_without_alternating() {
         let mut client = TestBlockChainClient::new();
@@ -855,6 +862,7 @@ mod tests {
         assert_eq!(0x02, queue.read()[1].packet_id);
     }
 
+    #[cfg(feature = "devP2PTests")]
     #[test]
     fn should_maintain_transactions_propagation_stats() {
         let (new_transaction_hashes_tx, new_transaction_hashes_rx) = crossbeam_channel::unbounded();
@@ -905,6 +913,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "devP2PTests")]
     #[test]
     fn should_propagate_service_transaction_to_selected_peers_only() {
         let mut client = TestBlockChainClient::new();
@@ -944,6 +953,7 @@ mod tests {
         assert_eq!(io.packets.len(), 2);
     }
 
+    #[cfg(feature = "devP2PTests")]
     #[test]
     fn should_propagate_service_transaction_is_sent_as_separate_message() {
         let mut client = TestBlockChainClient::new();
@@ -991,6 +1001,7 @@ mod tests {
         assert!(sent_transactions.iter().any(|tx| tx.hash() == tx2_hash));
     }
 
+    #[cfg(feature = "devP2PTests")]
     #[test]
     fn should_propagate_transactions_with_max_fee_per_gas_lower_than_base_fee() {
         let (new_transaction_hashes_tx, new_transaction_hashes_rx) = crossbeam_channel::unbounded();


### PR DESCRIPTION
This pull request includes several changes focused on improving code safety, adding clarity to comments, and refining functionality in the Ethereum consensus modules. The most important updates involve enhancing the safety of memory operations, improving documentation, and simplifying imports.

### Memory Safety Enhancements:
* [`crates/concensus/ethash/src/cache.rs`](diffhunk://#diff-1fbfdb00409701622a011ac23c47fa9c983e21ec9c2e03c42f6fc743888f5b4cR323): Added explicit `unsafe` blocks to the `initialize_memory` function to make the boundaries of unsafe code clearer and more maintainable. [[1]](diffhunk://#diff-1fbfdb00409701622a011ac23c47fa9c983e21ec9c2e03c42f6fc743888f5b4cR323) [[2]](diffhunk://#diff-1fbfdb00409701622a011ac23c47fa9c983e21ec9c2e03c42f6fc743888f5b4cR359-R360)
* [`crates/concensus/ethash/src/compute.rs`](diffhunk://#diff-4a8546b3eb8d3979c326c01eaaee51d8df73a72e18c18942efc4209891d6c4a4R185-R190): Wrapped unsafe type casting in an explicit `unsafe` block to improve code clarity and safety in the `hash_compute` function.

### Documentation Improvements:
* [`crates/concensus/miner/src/pool/queue.rs`](diffhunk://#diff-0eb431e5ed185108a9fd210c09e62210a59a12cecabced517dc0ac17dda43495L789-R795): Updated comments for clarity in the `TransactionQueue` implementation, distinguishing between enforced and non-enforced pending cache checks.

### Code Simplification:
* [`crates/concensus/miner/src/service_transaction_checker.rs`](diffhunk://#diff-688a5e0adc0a8405025c6d2434f472b369d8fa81ed2cebae17fa3d33e5ca0260L24-R24): Removed an unused `std::mem` import to clean up the codebase.