### PR TITLE
Prep release 0.11.0 rc2

### DIFF
--- a/bin/chainspec/src/main.rs
+++ b/bin/chainspec/src/main.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
-extern crate ethjson;
+use ethjson;
 extern crate serde_json;
 
 use ethjson::spec::Spec;

--- a/bin/ethstore/src/main.rs
+++ b/bin/ethstore/src/main.rs
@@ -17,7 +17,7 @@
 extern crate dir;
 extern crate docopt;
 extern crate ethstore;
-extern crate num_cpus;
+use num_cpus;
 extern crate panic_hook;
 extern crate parking_lot;
 extern crate rustc_hex;

--- a/bin/evmbin/benches/mod.rs
+++ b/bin/evmbin/benches/mod.rs
@@ -23,7 +23,7 @@
 #[macro_use]
 extern crate criterion;
 extern crate ethcore;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate evm;
 extern crate rustc_hex;
 extern crate vm;

--- a/bin/evmbin/src/main.rs
+++ b/bin/evmbin/src/main.rs
@@ -20,7 +20,7 @@
 
 extern crate common_types as types;
 extern crate ethcore;
-extern crate ethjson;
+use ethjson;
 extern crate rustc_hex;
 extern crate serde;
 #[macro_use]
@@ -29,7 +29,7 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate docopt;
 extern crate env_logger;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate evm;
 extern crate panic_hook;
 extern crate parity_bytes as bytes;

--- a/bin/oe/cli/mod.rs
+++ b/bin/oe/cli/mod.rs
@@ -1055,7 +1055,7 @@ mod tests {
     };
     use clap::ErrorKind as ClapErrorKind;
     use parity_version::NODE_SOFTWARE_NAME;
-    use toml;
+    
 
     #[test]
     fn should_accept_any_argument_order() {

--- a/bin/oe/cli/mod.rs
+++ b/bin/oe/cli/mod.rs
@@ -1055,7 +1055,6 @@ mod tests {
     };
     use clap::ErrorKind as ClapErrorKind;
     use parity_version::NODE_SOFTWARE_NAME;
-    
 
     #[test]
     fn should_accept_any_argument_order() {

--- a/bin/oe/configuration.rs
+++ b/bin/oe/configuration.rs
@@ -33,7 +33,6 @@ use ethcore::{
 };
 use ethereum_types::{Address, H256, U256};
 
-use num_cpus;
 use parity_version::{version, version_data};
 use std::{
     cmp,

--- a/bin/oe/db/rocksdb/blooms.rs
+++ b/bin/oe/db/rocksdb/blooms.rs
@@ -19,7 +19,6 @@
 use super::{kvdb_rocksdb::DatabaseConfig, open_database};
 use ethcore::error::Error;
 use ethereum_types::Bloom;
-use rlp;
 use std::path::Path;
 
 const LOG_BLOOMS_ELEMENTS_PER_INDEX: u64 = 16;

--- a/bin/oe/db/rocksdb/mod.rs
+++ b/bin/oe/db/rocksdb/mod.rs
@@ -22,7 +22,6 @@ use self::{
     ethcore_blockchain::{BlockChainDB, BlockChainDBHandler},
     kvdb_rocksdb::{Database, DatabaseConfig},
 };
-use blooms_db;
 use ethcore::client::ClientConfig;
 use ethcore_db::KeyValueDB;
 use stats::PrometheusMetrics;

--- a/bin/oe/informant.rs
+++ b/bin/oe/informant.rs
@@ -34,7 +34,6 @@ use crate::{
     sync::{ManageNetwork, SyncProvider},
     types::BlockNumber,
 };
-use atty;
 use ethcore::{
     client::{
         BlockChainClient, BlockChainInfo, BlockId, BlockInfo, BlockQueueInfo, ChainInfo,

--- a/bin/oe/lib.rs
+++ b/bin/oe/lib.rs
@@ -25,7 +25,6 @@ extern crate atty;
 extern crate dir;
 extern crate futures;
 extern crate jsonrpc_core;
-use num_cpus;
 extern crate number_prefix;
 extern crate parking_lot;
 extern crate regex;

--- a/bin/oe/lib.rs
+++ b/bin/oe/lib.rs
@@ -25,7 +25,7 @@ extern crate atty;
 extern crate dir;
 extern crate futures;
 extern crate jsonrpc_core;
-extern crate num_cpus;
+use num_cpus;
 extern crate number_prefix;
 extern crate parking_lot;
 extern crate regex;

--- a/bin/oe/lib.rs
+++ b/bin/oe/lib.rs
@@ -50,7 +50,7 @@ extern crate ethcore_miner as miner;
 extern crate ethcore_network as network;
 extern crate ethcore_service;
 extern crate ethcore_sync as sync;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate ethkey;
 extern crate ethstore;
 extern crate fetch;

--- a/bin/oe/signer.rs
+++ b/bin/oe/signer.rs
@@ -22,7 +22,6 @@ use std::{
 use crate::{path::restrict_permissions_owner, rpc, rpc_apis};
 use ansi_term::Colour::White;
 use ethcore_logger::Config as LogConfig;
-use parity_rpc;
 
 pub const CODES_FILENAME: &str = "authcodes";
 

--- a/crates/accounts/ethstore/src/lib.rs
+++ b/crates/accounts/ethstore/src/lib.rs
@@ -29,7 +29,7 @@ extern crate smallvec;
 extern crate tempdir;
 extern crate time;
 
-extern crate ethereum_types;
+use ethereum_types;
 extern crate ethkey as _ethkey;
 extern crate parity_crypto as crypto;
 extern crate parity_wordlist;

--- a/crates/accounts/ethstore/tests/api.rs
+++ b/crates/accounts/ethstore/tests/api.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
-extern crate ethereum_types;
+use ethereum_types;
 extern crate ethstore;
 extern crate parity_crypto as crypto;
 extern crate rand;

--- a/crates/concensus/ethash/src/lib.rs
+++ b/crates/concensus/ethash/src/lib.rs
@@ -15,7 +15,7 @@
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
 extern crate either;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate memmap;
 extern crate parking_lot;
 extern crate primal;

--- a/crates/concensus/miner/src/lib.rs
+++ b/crates/concensus/miner/src/lib.rs
@@ -24,7 +24,7 @@ extern crate common_types as types;
 extern crate ethabi;
 extern crate ethabi_derive;
 extern crate ethcore_call_contract as call_contract;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate futures;
 extern crate keccak_hash as hash;
 extern crate linked_hash_map;

--- a/crates/concensus/miner/stratum/src/lib.rs
+++ b/crates/concensus/miner/stratum/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Stratum protocol implementation for parity ethereum/bitcoin clients
 
-extern crate ethereum_types;
+use ethereum_types;
 extern crate jsonrpc_core;
 extern crate jsonrpc_tcp_server;
 extern crate keccak_hash as hash;

--- a/crates/db/journaldb/src/lib.rs
+++ b/crates/db/journaldb/src/lib.rs
@@ -20,7 +20,7 @@
 extern crate log;
 
 extern crate ethcore_db;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate fastmap;
 extern crate hash_db;
 extern crate keccak_hasher;

--- a/crates/db/patricia-trie-ethereum/src/lib.rs
+++ b/crates/db/patricia-trie-ethereum/src/lib.rs
@@ -17,7 +17,7 @@
 //! Façade crate for `patricia_trie` for Ethereum specific impls
 
 extern crate elastic_array;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate hash_db;
 extern crate keccak_hasher;
 extern crate parity_bytes;
@@ -47,7 +47,7 @@ pub type RlpCodec = RlpNodeCodec<KeccakHasher>;
 /// extern crate hash_db;
 /// extern crate keccak_hasher;
 /// extern crate memory_db;
-/// extern crate ethereum_types;
+/// use ethereum_types;
 /// extern crate elastic_array;
 /// extern crate journaldb;
 ///
@@ -92,7 +92,7 @@ pub type FatDB<'db> = trie::FatDB<'db, KeccakHasher, RlpCodec>;
 /// extern crate keccak_hash;
 /// extern crate keccak_hasher;
 /// extern crate memory_db;
-/// extern crate ethereum_types;
+/// use ethereum_types;
 /// extern crate elastic_array;
 /// extern crate journaldb;
 ///

--- a/crates/ethcore/benches/builtin.rs
+++ b/crates/ethcore/benches/builtin.rs
@@ -21,7 +21,7 @@ extern crate criterion;
 extern crate lazy_static;
 extern crate ethcore;
 extern crate ethcore_builtin;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate parity_bytes as bytes;
 extern crate rustc_hex;
 

--- a/crates/ethcore/service/src/lib.rs
+++ b/crates/ethcore/service/src/lib.rs
@@ -19,7 +19,7 @@ extern crate ethcore;
 extern crate ethcore_blockchain as blockchain;
 extern crate ethcore_io as io;
 extern crate ethcore_sync as sync;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate kvdb;
 
 #[macro_use]

--- a/crates/ethcore/src/engines/hbbft/hbbft_config_generator/src/main.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_config_generator/src/main.rs
@@ -2,8 +2,8 @@ extern crate bincode;
 #[macro_use]
 extern crate clap;
 extern crate ethcore;
-extern crate ethereum_types;
-extern crate ethjson;
+use ethereum_types;
+use ethjson;
 extern crate ethkey;
 extern crate ethstore;
 extern crate hbbft;

--- a/crates/ethcore/src/lib.rs
+++ b/crates/ethcore/src/lib.rs
@@ -19,7 +19,7 @@
 //! Ethcore library
 
 extern crate common_types as types;
-extern crate crossbeam_utils;
+use crossbeam_utils;
 extern crate derive_more;
 extern crate ethabi;
 extern crate ethash;
@@ -28,9 +28,9 @@ extern crate ethcore_builtin as builtin;
 extern crate ethcore_call_contract as call_contract;
 extern crate ethcore_db as db;
 extern crate ethcore_io as io;
-extern crate ethcore_miner;
-extern crate ethereum_types;
-extern crate ethjson;
+use ethcore_miner;
+use ethereum_types;
+use ethjson;
 extern crate fastmap;
 extern crate hash_db;
 extern crate hbbft;

--- a/crates/ethcore/src/lib.rs
+++ b/crates/ethcore/src/lib.rs
@@ -44,7 +44,7 @@ extern crate lru_cache;
 extern crate maplit;
 extern crate memory_cache;
 extern crate memory_db;
-extern crate num_cpus;
+use num_cpus;
 extern crate parity_bytes as bytes;
 extern crate parity_crypto as crypto;
 extern crate parity_snappy as snappy;

--- a/crates/ethcore/sync/src/lib.rs
+++ b/crates/ethcore/sync/src/lib.rs
@@ -28,7 +28,7 @@ extern crate ethcore_io as io;
 extern crate ethcore_network as network;
 extern crate ethcore_network_devp2p as devp2p;
 extern crate ethereum_forkid;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate ethkey;
 extern crate ethstore;
 extern crate fastmap;
@@ -61,7 +61,7 @@ extern crate macros;
 extern crate log;
 #[macro_use]
 extern crate trace_time;
-extern crate ethcore_miner;
+use ethcore_miner;
 
 mod block_sync;
 mod blocks;

--- a/crates/net/network-devp2p/src/lib.rs
+++ b/crates/net/network-devp2p/src/lib.rs
@@ -21,7 +21,7 @@
 //! ```rust
 //! extern crate ethcore_network as net;
 //! extern crate ethcore_network_devp2p as devp2p;
-//! extern crate ethereum_types as types;
+//! use ethereum_types as types;
 //! use net::*;
 //! use devp2p::NetworkService;
 //! use std::sync::Arc;
@@ -66,7 +66,7 @@ extern crate ansi_term; //TODO: remove this
 extern crate bytes;
 extern crate ethcore_io as io;
 extern crate ethcore_network as network;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate ethkey;
 extern crate igd;
 extern crate ipnetwork;

--- a/crates/net/network-devp2p/tests/tests.rs
+++ b/crates/net/network-devp2p/tests/tests.rs
@@ -18,7 +18,7 @@ extern crate env_logger;
 extern crate ethcore_io as io;
 extern crate ethcore_network;
 extern crate ethcore_network_devp2p;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate parity_bytes;
 extern crate parity_crypto as crypto;
 extern crate parking_lot;

--- a/crates/net/network/src/client_version.rs
+++ b/crates/net/network/src/client_version.rs
@@ -282,7 +282,6 @@ fn get_number_from_version(version: &str) -> Option<&str> {
     None
 }
 
-
 #[cfg(test)]
 pub mod tests {
     use super::*;

--- a/crates/net/network/src/client_version.rs
+++ b/crates/net/network/src/client_version.rs
@@ -282,6 +282,7 @@ fn get_number_from_version(version: &str) -> Option<&str> {
     None
 }
 
+
 #[cfg(test)]
 pub mod tests {
     use super::*;

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -17,7 +17,7 @@
 #![recursion_limit = "128"]
 
 extern crate ethcore_io as io;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate ethkey;
 extern crate ipnetwork;
 extern crate libc;

--- a/crates/net/node-filter/src/lib.rs
+++ b/crates/net/node-filter/src/lib.rs
@@ -20,7 +20,7 @@ extern crate ethabi;
 extern crate ethcore;
 extern crate ethcore_network as network;
 extern crate ethcore_network_devp2p as devp2p;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate lru_cache;
 extern crate parking_lot;
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -65,7 +65,7 @@ extern crate ethcore_logger;
 extern crate ethcore_miner as miner;
 extern crate ethcore_network as network;
 extern crate ethcore_sync as sync;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate ethkey;
 extern crate ethstore;
 extern crate fetch;
@@ -90,7 +90,7 @@ extern crate log;
 extern crate serde_derive;
 
 #[cfg(test)]
-extern crate ethjson;
+use ethjson;
 
 #[cfg(test)]
 #[macro_use]

--- a/crates/runtime/io/src/lib.rs
+++ b/crates/runtime/io/src/lib.rs
@@ -76,7 +76,7 @@ extern crate log as rlog;
 extern crate crossbeam_deque as deque;
 extern crate fnv;
 extern crate futures;
-extern crate num_cpus;
+use num_cpus;
 extern crate parking_lot;
 extern crate slab;
 extern crate time;

--- a/crates/util/cli-signer/rpc-client/src/lib.rs
+++ b/crates/util/cli-signer/rpc-client/src/lib.rs
@@ -17,7 +17,7 @@
 pub mod client;
 pub mod signer_client;
 
-extern crate ethereum_types;
+use ethereum_types;
 extern crate futures;
 extern crate jsonrpc_core;
 extern crate jsonrpc_ws_server as ws;

--- a/crates/util/cli-signer/src/lib.rs
+++ b/crates/util/cli-signer/src/lib.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
-extern crate ethereum_types;
+use ethereum_types;
 extern crate futures;
 extern crate rpassword;
 

--- a/crates/util/dir/src/lib.rs
+++ b/crates/util/dir/src/lib.rs
@@ -38,7 +38,7 @@
 /// Unix: $BASE/openethereum/
 ///
 extern crate app_dirs;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate home;
 extern crate journaldb;
 

--- a/crates/util/fastmap/src/lib.rs
+++ b/crates/util/fastmap/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Provides a `H256FastMap` type with H256 keys and fast hashing function.
 
-extern crate ethereum_types;
+use ethereum_types;
 extern crate lru;
 extern crate plain_hasher;
 

--- a/crates/util/keccak-hasher/src/lib.rs
+++ b/crates/util/keccak-hasher/src/lib.rs
@@ -15,7 +15,7 @@
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Hasher implementation for the Keccak-256 hash
-extern crate ethereum_types;
+use ethereum_types;
 extern crate hash_db;
 extern crate plain_hasher;
 extern crate tiny_keccak;

--- a/crates/util/triehash-ethereum/src/lib.rs
+++ b/crates/util/triehash-ethereum/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Generates Keccak-flavoured trie roots.
 
-extern crate ethereum_types;
+use ethereum_types;
 extern crate keccak_hasher;
 extern crate triehash;
 

--- a/crates/vm/evm/benches/basic.rs
+++ b/crates/vm/evm/benches/basic.rs
@@ -19,7 +19,7 @@
 #[macro_use]
 extern crate criterion;
 extern crate bit_set;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate evm;
 extern crate keccak_hash as hash;
 extern crate memory_cache;

--- a/crates/vm/evm/src/lib.rs
+++ b/crates/vm/evm/src/lib.rs
@@ -18,7 +18,7 @@
 
 extern crate bit_set;
 extern crate ethcore_builtin as builtin;
-extern crate ethereum_types;
+use ethereum_types;
 extern crate keccak_hash as hash;
 extern crate memory_cache;
 extern crate num_bigint;

--- a/crates/vm/vm/src/lib.rs
+++ b/crates/vm/vm/src/lib.rs
@@ -16,8 +16,8 @@
 
 //! Virtual machines support library
 
-extern crate ethereum_types;
-extern crate ethjson;
+use ethereum_types;
+use ethjson;
 extern crate keccak_hash as hash;
 extern crate parity_bytes as bytes;
 extern crate patricia_trie_ethereum as ethtrie;

--- a/crates/vm/wasm/src/lib.rs
+++ b/crates/vm/wasm/src/lib.rs
@@ -17,7 +17,7 @@
 //! Wasm Interpreter
 
 extern crate byteorder;
-extern crate ethereum_types;
+use ethereum_types;
 #[macro_use]
 extern crate log;
 extern crate libc;


### PR DESCRIPTION
This pull request refactors the codebase to replace `extern crate` declarations with `use` statements for the `ethereum_types` crate across multiple files. This change modernizes the codebase to align with Rust 2018 edition conventions, which encourage the use of `use` statements instead of `extern crate`.

### Refactoring to use `use ethereum_types`:

* Replaced `extern crate ethereum_types` with `use ethereum_types` in several files, including `lib.rs` files under `accounts/ethstore`, `concensus/ethash`, `concensus/miner`, `db/journaldb`, `db/patricia-trie-ethereum`, `ethcore`, `ethcore/sync`, `net/network`, `net/network-devp2p`, `rpc`, `runtime/io`, and `util/cli-signer` directories. [[1]](diffhunk://#diff-6c513558abf402f5d777ed0e8ecfe4f946b9e7a53aa9bf28140a6265bdbdd8bcL32-R32) [[2]](diffhunk://#diff-f1cecb52dc2d9d496228fcffcfdabcef2ced61c6def088d02ddc787a29d7e8edL18-R18) [[3]](diffhunk://#diff-e3d7150c6b986d27987170fcfd7ce0b368f0ff3b80d07cc0ad5abaae82ec63f8L27-R27) [[4]](diffhunk://#diff-7c2a27a296750a9a9ba0882592e91a2e84dba102642d35f8615651b8bc0b6b14L23-R23) [[5]](diffhunk://#diff-935a3865c17e2c208cb9e964c3212d18ff192c7f6c2cf1b48b17625a2db777d5L20-R20) [[6]](diffhunk://#diff-7ff9f05283f693443520ec956ad9bb88fdcff41c1197a6405ed8f88c22d6ecfcL24-R24) [[7]](diffhunk://#diff-179eec6f21b296ed4f9b413a275055f9e421451fe7d2ac05cdac3260b932a3efL22-R22) [[8]](diffhunk://#diff-d771307f40ffc2443197f53bb3174aeda7add9f56a4ec4e3898ed1bbdb5ad923L31-R31) [[9]](diffhunk://#diff-2657f56787c5a4fc5f93b692d232a0c22a9584938d3a9b158e807aa97b4199cfL69-R69) [[10]](diffhunk://#diff-384b7582d19640bba658a54e3a12e279ae816d7caa8e0fd9d260aa55c76b8356L68-R68) [[11]](diffhunk://#diff-c4ffbacaeaf9ac6814d4e54581da3668c16352d5c78aa771d806dc7ab621de43L79-R79) [[12]](diffhunk://#diff-9b1b5f740d4608172aa745879e1b8712c2cef01054284efa7dd952168e30671aL20-R20) [[13]](diffhunk://#diff-0fdc8fd2f878feff55528a766b3419130c74cb92b682c0442ee393f42e0a2f9eL17-R17)

* Updated test files to follow the same pattern, replacing `extern crate ethereum_types` with `use ethereum_types` in files like `api.rs` and `tests.rs`. [[1]](diffhunk://#diff-8b134d84d73312bae0df96a934c9a7022c603c6cffd78397d04d5652ba43c30bL17-R17) [[2]](diffhunk://#diff-5cb4b6ebaff3f3523cc64303f29f15e9f20c7281d4cde9213685cfe5decdde1fL21-R21)

* Adjusted commented-out examples and documentation to reflect the updated syntax, such as in `network-devp2p/src/lib.rs`.

* Removed additional `extern crate` declarations for other crates, such as `ethjson`, and replaced them with `use` statements where applicable. [[1]](diffhunk://#diff-0d7aa6333b65beccf9f9d99434af247def23c96fa29f4ca0a311250bc3b0f078L5-R6) [[2]](diffhunk://#diff-73cb450e3eba1a8eb670d8acdb3cddc59dccfdb9e023eaa6debff8d376fc5511L31-R33) [[3]](diffhunk://#diff-384b7582d19640bba658a54e3a12e279ae816d7caa8e0fd9d260aa55c76b8356L93-R93)

This change improves code readability, reduces boilerplate, and brings the project in line with modern Rust practices.