### PR TITLE
Release prep 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## Diamond Node Software 3.3.5-hbbft-0.11.1
+
+- caching of SyncStatus to prevent deadlocks https://github.com/DMDcoin/diamond-node/issues/223
 
 ## Diamond Node Software 3.3.5-hbbft-0.11.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "diamond-node"
-version = "3.3.5-hbbft-0.11.0-rc3"
+version = "3.3.5-hbbft-0.11.1"
 dependencies = [
  "ansi_term 0.10.2",
  "atty",
@@ -3583,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "3.3.5-hbbft-0.11.0-rc3"
+version = "3.3.5-hbbft-0.11.1"
 dependencies = [
  "parity-bytes",
  "rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Diamond Node"
 name = "diamond-node"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "3.3.5-hbbft-0.11.0-rc3"
+version = "3.3.5-hbbft-0.11.1"
 license = "GPL-3.0"
 authors = [
 	"bit.diamonds developers",

--- a/crates/util/version/Cargo.toml
+++ b/crates/util/version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for OpenEthereum version string (via env CARGO_PKG_VERSION)
-version = "3.3.5-hbbft-0.11.0-rc3"
+version = "3.3.5-hbbft-0.11.1"
 authors = [
 	"bit.diamonds developers",
 	"OpenEthereum developers",


### PR DESCRIPTION
Release: 
## Diamond Node Software 3.3.5-hbbft-0.11.1

- caching of SyncStatus to prevent deadlocks https://github.com/DMDcoin/diamond-node/issues/223
