### PR TITLE
shutdown on deadlock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ lazy_static = "1.2.0"
 winapi = { version = "0.3.4", features = ["winsock2", "winuser", "shellapi"] }
 
 [features]
-default = ["accounts"]
+default = ["shutdown-on-deadlock", "accounts"]
 accounts = ["ethcore-accounts", "parity-rpc/accounts"]
 miner-debug = ["ethcore/miner-debug"]
 json-tests = ["ethcore/json-tests"]
@@ -118,6 +118,7 @@ deadlock_detection = ["parking_lot/deadlock_detection"]
 # and `massif-visualizer` for visualization
 memory_profiling = []
 secretstore = []
+shutdown-on-deadlock = ["deadlock_detection"]
 
 [lib]
 path = "bin/oe/lib.rs"

--- a/bin/oe/blockchain.rs
+++ b/bin/oe/blockchain.rs
@@ -214,7 +214,7 @@ fn execute_import(cmd: ImportBlockchain) -> Result<(), String> {
         // TODO [ToDr] don't use test miner here
         // (actually don't require miner at all)
         Arc::new(Miner::new_for_tests(&spec, None)),
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )
     .map_err(|e| format!("Client service error: {:?}", e))?;
 
@@ -282,7 +282,7 @@ fn start_client(
     require_fat_db: bool,
     max_round_blocks_to_import: usize,
     shutdown_on_missing_block_import: Option<u64>,
-    shutdown: ShutdownManager,
+    shutdown: Arc<ShutdownManager>,
 ) -> Result<ClientService, String> {
     // load spec file
     let spec = spec.spec(&dirs.cache)?;
@@ -376,7 +376,7 @@ fn execute_export(cmd: ExportBlockchain) -> Result<(), String> {
         false,
         cmd.max_round_blocks_to_import,
         None,
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )?;
     let client = service.client();
 
@@ -407,7 +407,7 @@ fn execute_export_state(cmd: ExportState) -> Result<(), String> {
         true,
         cmd.max_round_blocks_to_import,
         None,
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )?;
 
     let client = service.client();
@@ -527,7 +527,7 @@ fn execute_reset(cmd: ResetBlockchain) -> Result<(), String> {
         false,
         0,
         None,
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )?;
 
     let client = service.client();

--- a/bin/oe/run.rs
+++ b/bin/oe/run.rs
@@ -177,7 +177,7 @@ impl ChainSyncing for SyncProviderWrapper {
 pub fn execute(
     cmd: RunCmd,
     logger: Arc<RotatingLogger>,
-    shutdown: ShutdownManager,
+    shutdown: Arc<ShutdownManager>,
 ) -> Result<RunningClient, String> {
     // load spec
     let spec = cmd.spec.spec(&cmd.dirs.cache)?;
@@ -755,8 +755,8 @@ fn print_running_environment(data_dir: &str, dirs: &Directories, db_dirs: &Datab
 
 fn wait_for_drop<T>(w: Weak<T>) {
     const SLEEP_DURATION: Duration = Duration::from_secs(1);
-    const WARN_TIMEOUT: Duration = Duration::from_secs(60);
-    const MAX_TIMEOUT: Duration = Duration::from_secs(300);
+    const WARN_TIMEOUT: Duration = Duration::from_secs(30);
+    const MAX_TIMEOUT: Duration = Duration::from_secs(60);
 
     let instant = Instant::now();
     let mut warned = false;

--- a/bin/oe/snapshot.rs
+++ b/bin/oe/snapshot.rs
@@ -241,7 +241,7 @@ impl SnapshotCommand {
             // TODO [ToDr] don't use test miner here
             // (actually don't require miner at all)
             Arc::new(Miner::new_for_tests(&spec, None)),
-            ShutdownManager::null(),
+            Arc::new(ShutdownManager::null()),
         )
         .map_err(|e| format!("Client service error: {:?}", e))?;
 

--- a/crates/ethcore/service/src/service.rs
+++ b/crates/ethcore/service/src/service.rs
@@ -58,7 +58,7 @@ impl ClientService {
         restoration_db_handler: Box<dyn BlockChainDBHandler>,
         _ipc_path: &Path,
         miner: Arc<Miner>,
-        shutdown: ShutdownManager,
+        shutdown: Arc<ShutdownManager>,
     ) -> Result<ClientService, Error> {
         let io_service = IoService::<ClientIoMessage>::start("Client", 4)?;
 

--- a/crates/ethcore/service/src/service.rs
+++ b/crates/ethcore/service/src/service.rs
@@ -274,7 +274,7 @@ mod tests {
             restoration_db_handler,
             tempdir.path(),
             Arc::new(Miner::new_for_tests(&spec, None)),
-            ShutdownManager::null(),
+            Arc(ShutdownManager::null()),
         );
         assert!(service.is_ok());
         drop(service.unwrap());

--- a/crates/ethcore/service/src/service.rs
+++ b/crates/ethcore/service/src/service.rs
@@ -274,7 +274,7 @@ mod tests {
             restoration_db_handler,
             tempdir.path(),
             Arc::new(Miner::new_for_tests(&spec, None)),
-            Arc(ShutdownManager::null()),
+            Arc::new(ShutdownManager::null()),
         );
         assert!(service.is_ok());
         drop(service.unwrap());

--- a/crates/ethcore/src/client/client.rs
+++ b/crates/ethcore/src/client/client.rs
@@ -304,7 +304,7 @@ pub struct Client {
 
     importer: Importer,
 
-    shutdown: ShutdownManager,
+    shutdown: Arc<ShutdownManager>,
 
     statistics: ClientStatistics,
 }
@@ -994,7 +994,7 @@ impl Client {
         db: Arc<dyn BlockChainDB>,
         miner: Arc<Miner>,
         message_channel: IoChannel<ClientIoMessage>,
-        shutdown: ShutdownManager,
+        shutdown: Arc<ShutdownManager>,
     ) -> Result<Arc<Client>, crate::error::Error> {
         let trie_spec = match config.fat_db {
             true => TrieSpec::Fat,

--- a/crates/ethcore/src/json_tests/chain.rs
+++ b/crates/ethcore/src/json_tests/chain.rs
@@ -203,7 +203,7 @@ pub fn json_chain_test<H: FnMut(&str, HookType)>(
                     db,
                     Arc::new(Miner::new_for_tests(&spec, None)),
                     IoChannel::disconnected(),
-                    ShutdownManager::null(),
+                    Arc::new(ShutdownManager::null()),
                 )
                 .expect("Failed to instantiate a new Client");
 

--- a/crates/ethcore/src/snapshot/tests/service.rs
+++ b/crates/ethcore/src/snapshot/tests/service.rs
@@ -71,7 +71,7 @@ fn restored_is_equivalent() {
         blockchain_db,
         Arc::new(crate::miner::Miner::new_for_tests(&spec, None)),
         IoChannel::disconnected(),
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )
     .unwrap();
 
@@ -235,7 +235,7 @@ fn keep_ancient_blocks() {
         client_db,
         Arc::new(crate::miner::Miner::new_for_tests(&spec, None)),
         IoChannel::disconnected(),
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )
     .unwrap();
 
@@ -324,7 +324,7 @@ fn recover_aborted_recovery() {
         client_db,
         Arc::new(crate::miner::Miner::new_for_tests(&spec, None)),
         IoChannel::disconnected(),
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )
     .unwrap();
     let service_params = ServiceParams {

--- a/crates/ethcore/src/test_helpers.rs
+++ b/crates/ethcore/src/test_helpers.rs
@@ -169,7 +169,7 @@ where
         client_db,
         Arc::new(miner),
         IoChannel::disconnected(),
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )
     .unwrap();
     let test_engine = &*test_spec.engine;
@@ -377,7 +377,7 @@ pub fn get_test_client_with_blocks(blocks: Vec<Bytes>) -> Arc<Client> {
         client_db,
         Arc::new(Miner::new_for_tests(&test_spec, None)),
         IoChannel::disconnected(),
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )
     .unwrap();
 

--- a/crates/ethcore/src/tests/client.rs
+++ b/crates/ethcore/src/tests/client.rs
@@ -67,7 +67,7 @@ fn imports_from_empty() {
         db,
         Arc::new(Miner::new_for_tests(&spec, None)),
         IoChannel::disconnected(),
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )
     .unwrap();
     client.import_verified_blocks();
@@ -86,7 +86,7 @@ fn should_return_registrar() {
         db,
         Arc::new(Miner::new_for_tests(&spec, None)),
         IoChannel::disconnected(),
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )
     .unwrap();
     let params = client.additional_params();
@@ -107,7 +107,7 @@ fn imports_good_block() {
         db,
         Arc::new(Miner::new_for_tests(&spec, None)),
         IoChannel::disconnected(),
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )
     .unwrap();
     let good_block = get_good_dummy_block();
@@ -135,7 +135,7 @@ fn query_none_block() {
         db,
         Arc::new(Miner::new_for_tests(&spec, None)),
         IoChannel::disconnected(),
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )
     .unwrap();
     let non_existant = client.block_header(BlockId::Number(188));
@@ -338,7 +338,7 @@ fn change_history_size() {
             db.clone(),
             Arc::new(Miner::new_for_tests(&test_spec, None)),
             IoChannel::disconnected(),
-            ShutdownManager::null(),
+            Arc::new(ShutdownManager::null()),
         )
         .unwrap();
 
@@ -371,7 +371,7 @@ fn change_history_size() {
         db,
         Arc::new(Miner::new_for_tests(&test_spec, None)),
         IoChannel::disconnected(),
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )
     .unwrap();
     assert_eq!(client.state().balance(&address).unwrap(), 100.into());

--- a/crates/ethcore/src/tests/trace.rs
+++ b/crates/ethcore/src/tests/trace.rs
@@ -54,7 +54,7 @@ fn can_trace_block_and_uncle_reward() {
         db,
         Arc::new(Miner::new_for_tests(&spec, None)),
         IoChannel::disconnected(),
-        ShutdownManager::null(),
+        Arc::new(ShutdownManager::null()),
     )
     .unwrap();
 

--- a/crates/ethcore/src/tx_filter.rs
+++ b/crates/ethcore/src/tx_filter.rs
@@ -312,7 +312,7 @@ mod test {
             db,
             Arc::new(Miner::new_for_tests(&spec, None)),
             IoChannel::disconnected(),
-            ShutdownManager::null(),
+            Arc::new(ShutdownManager::null()),
         )
         .unwrap();
         let key1 = KeyPair::from_secret(
@@ -554,7 +554,7 @@ mod test {
             db,
             Arc::new(Miner::new_for_tests(&spec, None)),
             IoChannel::disconnected(),
-            ShutdownManager::null(),
+            Arc::new(ShutdownManager::null()),
         )
         .unwrap();
         let key1 = KeyPair::from_secret(
@@ -623,7 +623,7 @@ mod test {
             db,
             Arc::new(Miner::new_for_tests(&spec, None)),
             IoChannel::disconnected(),
-            ShutdownManager::null(),
+            Arc::new(ShutdownManager::null()),
         )
         .unwrap();
         let key1 = KeyPair::from_secret(
@@ -692,7 +692,7 @@ mod test {
             db,
             Arc::new(Miner::new_for_tests(&spec, None)),
             IoChannel::disconnected(),
-            ShutdownManager::null(),
+            Arc::new(ShutdownManager::null()),
         )
         .unwrap();
         let key1 = KeyPair::from_secret(
@@ -764,7 +764,7 @@ mod test {
             db,
             Arc::new(Miner::new_for_tests(&spec, None)),
             IoChannel::disconnected(),
-            ShutdownManager::null(),
+            Arc::new(ShutdownManager::null()),
         )
         .unwrap();
         let key1 = KeyPair::from_secret(

--- a/crates/ethcore/sync/src/tests/helpers.rs
+++ b/crates/ethcore/sync/src/tests/helpers.rs
@@ -451,7 +451,7 @@ impl TestNet<EthPeer<EthcoreClient>> {
             test_helpers::new_db(),
             miner.clone(),
             channel.clone(),
-            ShutdownManager::null(),
+            Arc::new(ShutdownManager::null()),
         )
         .unwrap();
 

--- a/crates/net/node-filter/src/lib.rs
+++ b/crates/net/node-filter/src/lib.rs
@@ -128,7 +128,7 @@ mod test {
             client_db,
             Arc::new(Miner::new_for_tests(&spec, None)),
             IoChannel::disconnected(),
-            ShutdownManager::null(),
+            Arc::new(ShutdownManager::null()),
         )
         .unwrap();
         let filter = NodeFilter::new(

--- a/crates/rpc/src/v1/tests/eth.rs
+++ b/crates/rpc/src/v1/tests/eth.rs
@@ -129,7 +129,7 @@ impl EthTester {
             test_helpers::new_db(),
             miner_service.clone(),
             IoChannel::disconnected(),
-            ShutdownManager::null(),
+            Arc::new(ShutdownManager::null()),
         )
         .unwrap();
         let sync_provider = sync_provider();


### PR DESCRIPTION
https://github.com/DMDcoin/diamond-node/issues/231 shutdown on deadlock

On detecting a deadlock, we are shutting down the Node Software now if the feature "shutdown-on-deadlock" is defined, and is activated as a default feature for now.

Shutdowns are now timed to take a maximum of 60 seconds, instead of 300 seconds.  Code Infrastructure changes: ShutdownManager is now hosted as an Arc.

### Feature Enhancements:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L102-R102): Added a new feature flag `shutdown-on-deadlock`, which enables deadlock detection by leveraging the `parking_lot/deadlock_detection` feature. This is now part of the default feature set. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L102-R102) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R121)

### Code Refactoring:
* [`crates/ethcore/service/src/service.rs`](diffhunk://#diff-bbe545ea72be0ab87ae90cc9df2e8ddfbf020346560b9715e2eae26e617ae487L61-R61): Updated the `shutdown` field in the `ClientService` constructor to use `Arc<ShutdownManager>` instead of `ShutdownManager` for better thread safety.
* [`crates/ethcore/src/client/client.rs`](diffhunk://#diff-8876a2ea46c1e14dd82cd2f544ac97ac66a2aed26afdf03c8f90449e6adafc32L307-R307): Refactored the `shutdown` field in the `Client` struct and its constructor to use `Arc<ShutdownManager>`, ensuring consistent shared ownership across threads. [[1]](diffhunk://#diff-8876a2ea46c1e14dd82cd2f544ac97ac66a2aed26afdf03c8f90449e6adafc32L307-R307) [[2]](diffhunk://#diff-8876a2ea46c1e14dd82cd2f544ac97ac66a2aed26afdf03c8f90449e6adafc32L997-R997)