### PR TITLE
I270 joining hbbft epoch after sync

### DIFF
--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -468,7 +468,7 @@ impl HoneyBadgerBFT {
             machine,
             hbbft_state: RwLock::new(HbbftState::new()),
             hbbft_message_dispatcher: HbbftMessageDispatcher::new(
-                params.blocks_to_keep_on_disk.unwrap_or(1),
+                params.blocks_to_keep_on_disk.unwrap_or(0),
                 params
                     .blocks_to_keep_directory
                     .clone()


### PR DESCRIPTION
[not joining hbbft epoch after sync has finished.](https://github.com/DMDcoin/diamond-node/issues/270)

**Delayed HBBFT Join Mechanism:**

- Added a new `delayed_hbbft_join` field (an `AtomicBool`) to the `HoneyBadgerBFT` struct to track when a join to the HBBFT epoch should be retried after syncing. [[1]](diffhunk://#diff-a850cb878549a522cea1c384813a533d5cf74ce479af4cf4e3abbb3981fdea9cR105) [[2]](diffhunk://#diff-a850cb878549a522cea1c384813a533d5cf74ce479af4cf4e3abbb3981fdea9cL472-R492)
- Updated the `join_hbbft_epoch` method to set `delayed_hbbft_join` to `true` if the node is still syncing, and to clear and log when resuming the join after sync.
- Modified the epoch transition handler to check `delayed_hbbft_join` and attempt to join the epoch after synchronization is complete, logging any errors.

**Preparation for Message Replay:**

- Added comments and placeholders for replaying disk-cached messages upon hardfork and engine initialization, indicating future work to handle message replay for RBC (Reliable Broadcast Channel). [[1]](diffhunk://#diff-a850cb878549a522cea1c384813a533d5cf74ce479af4cf4e3abbb3981fdea9cR1322-R1324) [[2]](diffhunk://#diff-a850cb878549a522cea1c384813a533d5cf74ce479af4cf4e3abbb3981fdea9cR512-R513)

**Testing Improvements:**

- Updated HBBFT test setup to allow up to 20 future epochs, improving test coverage for future-epoch handling.