### PR TITLE
I270 joining hbbft epoch after sync

### DIFF
--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -1691,7 +1691,7 @@ mod tests {
 
         let mut builder: HoneyBadgerBuilder<Contribution, _> =
             HoneyBadger::builder(Arc::new(net_info.clone()));
-        builder.max_future_epochs(20);
+        builder.max_future_epochs(0);
 
         let mut honey_badger = builder.build();
 

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -468,7 +468,7 @@ impl HoneyBadgerBFT {
             machine,
             hbbft_state: RwLock::new(HbbftState::new()),
             hbbft_message_dispatcher: HbbftMessageDispatcher::new(
-                params.blocks_to_keep_on_disk.unwrap_or(1),
+                params.blocks_to_keep_on_disk.unwrap_or(0),
                 params
                     .blocks_to_keep_directory
                     .clone()


### PR DESCRIPTION
https://github.com/DMDcoin/diamond-node/issues/270

This pull request makes a minor adjustment to the HoneyBadger consensus test configuration. The change sets the maximum number of future epochs to zero, which will affect how the consensus engine handles future epochs during testing.

* In the `mod tests` section of `crates/ethcore/src/engines/hbbft/hbbft_engine.rs`, the call to `builder.max_future_epochs` is changed from `20` to `0`.