### PR TITLE
Hotfix: Nodes not fast enough to write parts (keygen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Diamond Node Software 0.12.2
+
+- [Hotfix: Nodes not fast enough to write parts (keygen)](https://github.com/DMDcoin/diamond-node/issues/280)
+
+## Diamond Node Software 0.12.1
+
+- Logging improvements
+- Fixed a bug, where handshakes, that get upgraded to sessions, deregister there stream.  
+
+
 ## Diamond Node Software 0.12.0
 
 - New Versioning Scheme: Since Open Ethereum did not get a new update, diamond-node will not mention 3.3.5 anymore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "diamond-node"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "ansi_term 0.10.2",
  "atty",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "parity-bytes",
  "rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Diamond Node"
 name = "diamond-node"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "0.12.1"
+version = "0.12.2"
 license = "GPL-3.0"
 authors = [
 	"bit.diamonds developers",

--- a/crates/ethcore/src/engines/hbbft/keygen_transactions.rs
+++ b/crates/ethcore/src/engines/hbbft/keygen_transactions.rs
@@ -57,7 +57,7 @@ impl From<CallError> for KeyGenError {
     }
 }
 
-static KEYGEN_TRANSACTION_SEND_DELAY: u64 = 3;
+static KEYGEN_TRANSACTION_SEND_DELAY: u64 = 0;
 static KEYGEN_TRANSACTION_RESEND_DELAY: u64 = 10;
 
 impl KeygenTransactionSender {

--- a/crates/util/version/Cargo.toml
+++ b/crates/util/version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for OpenEthereum version string (via env CARGO_PKG_VERSION)
-version = "0.12.1"
+version = "0.12.2"
 authors = [
 	"bit.diamonds developers",
 	"OpenEthereum developers",


### PR DESCRIPTION
https://github.com/DMDcoin/diamond-node/issues/280

- Instead of waiting 3 Blocks they are send immeadially (risking they get reverted since the State DB of clients is not up to date)
+ version update