### PR TITLE
Log improvements 4.0.3

### DIFF
--- a/crates/concensus/miner/src/pool/queue.rs
+++ b/crates/concensus/miner/src/pool/queue.rs
@@ -475,13 +475,13 @@ impl TransactionQueue {
                 .read()
                 .pending(block_number, current_timestamp, nonce_cap.as_ref(), max_len)
         {
-            // Returning a cached pending set here, 
+            // Returning a cached pending set here,
             // could lead to a situation where the cache was constructed before
             // the cleanup of the pool did finish for the last block import.
             // this could lead to "pending" transactions that were already
             // included in the last set,
             // if there is no mechanism that removes the transactions from that pool.
-            
+
             return pending;
         }
 

--- a/crates/concensus/miner/src/pool/queue.rs
+++ b/crates/concensus/miner/src/pool/queue.rs
@@ -475,6 +475,13 @@ impl TransactionQueue {
                 .read()
                 .pending(block_number, current_timestamp, nonce_cap.as_ref(), max_len)
         {
+            // Returning a cached pending set here, 
+            // could lead to a situation where the cache was constructed before
+            // the cleanup of the pool did finish for the last block import.
+            // this could lead to "pending" transactions that were already
+            // included in the last set,
+            // if there is no mechanism that removes the transactions from that pool.
+            
             return pending;
         }
 

--- a/crates/ethcore/src/engines/hbbft/hbbft_early_epoch_end_manager.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_early_epoch_end_manager.rs
@@ -303,7 +303,7 @@ impl HbbftEarlyEpochEndManager {
             // todo: this is max blocktime (heartbeat) x 2, better read the maximum blocktime.
             // on phoenix protocol triggers, this would also skip the sending of disconnectivity reports.
             if elapsed_since_last_block > 10 * 60 {
-                info!(target:"engine", "skipping early-epoch-end: now {now} ; block_time {block_time}: Block WAS created in the future ?!?! :-x. not sending early epoch end reports.");
+                info!(target:"engine", "skipping early-epoch-end: elapsed time since last block: {elapsed_since_last_block}. not sending early epoch end reports if there is no block production.");
                 return;
             }
         } else {

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -1082,8 +1082,23 @@ impl HoneyBadgerBFT {
         if let Some(block_header) = client.block_header(BlockId::Latest) {
             let target_min_timestamp = block_header.timestamp() + self.params.minimum_block_time;
             let now = unix_now_secs();
+
+            // todo:
+            // empty blocks
+            // there could be cases, where the transactions that got included in the last block,
+            // have not been removed from the mem pool yet.
+            // we could check here the completion of the transaction pool maintenance,
+            // and either wait, or just do nothing in this case, since the next engine tick,
+            // will just call this again.
+
             // we could implement a cheaper way to get the number of queued transaction, that does not require this intensive locking.
             // see: https://github.com/DMDcoin/diamond-node/issues/237
+
+            // what is the best set of transactions ??
+            // pending_transactions() vs queued_transactions() vs ready_transactions()
+            // the proposal generation is done with "queued_transactions()" 
+            // queued transactions = transaction_queue.pending
+
             let queue_length = client.queued_transactions().len();
             (self.params.minimum_block_time == 0 || target_min_timestamp <= now)
                 && queue_length >= self.params.transaction_queue_size_trigger

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -1617,8 +1617,6 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
             //     }
             // );
             // setting peers management here.
-
-            warn!(target: "engine", "set_signer - update_honeybadger...");
             if let None = self.hbbft_state.write().update_honeybadger(
                 client,
                 &self.signer,

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -1609,26 +1609,6 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
         }
 
         *self.signer.write() = signer;
-
-        if let Some(client) = self.client_arc() {
-            // client.as_full_client().and_then(|c| {
-            //     self.peers_management.lock().set_peers_management(self.peers_management.clone());
-            //     None
-            //     }
-            // );
-            // setting peers management here.
-            if let None = self.hbbft_state.write().update_honeybadger(
-                client,
-                &self.signer,
-                &self.hbbft_peers_service,
-                &self.early_epoch_manager,
-                &self.current_minimum_gas_price,
-                BlockId::Latest,
-                true,
-            ) {
-                info!(target: "engine", "HoneyBadger Algorithm could not be created, Client possibly not set yet.");
-            }
-        }
     }
 
     fn sign(&self, hash: H256) -> Result<Signature, Error> {

--- a/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
+++ b/crates/ethcore/src/engines/hbbft/hbbft_engine.rs
@@ -1096,7 +1096,7 @@ impl HoneyBadgerBFT {
 
             // what is the best set of transactions ??
             // pending_transactions() vs queued_transactions() vs ready_transactions()
-            // the proposal generation is done with "queued_transactions()" 
+            // the proposal generation is done with "queued_transactions()"
             // queued transactions = transaction_queue.pending
 
             let queue_length = client.queued_transactions().len();

--- a/crates/ethcore/sync/src/api.rs
+++ b/crates/ethcore/sync/src/api.rs
@@ -764,7 +764,7 @@ impl ChainNotify for EthSync {
                 ChainMessageType::Consensus(block, message) => {
                     let send_result = self.eth_handler.sync.write().send_consensus_packet(&mut sync_io, message.clone(), node_id);
                     if let Err(e) = send_result {
-                        info!(target: "consensus", "Error sending consensus message to peer - caching message {:?}: {:?}", node_id, e);
+                        debug!(target: "consensus", "Error sending consensus message to peer - caching message {:?}: {:?}", node_id, e);
                         // If we failed to send the message, cache it for later
                         let mut lock = self.eth_handler.message_cache.write();
                         lock.entry(Some(node_id.clone())).or_default().push(ChainMessageType::Consensus(block, message));

--- a/crates/ethcore/sync/src/api.rs
+++ b/crates/ethcore/sync/src/api.rs
@@ -764,7 +764,7 @@ impl ChainNotify for EthSync {
                 ChainMessageType::Consensus(block, message) => {
                     let send_result = self.eth_handler.sync.write().send_consensus_packet(&mut sync_io, message.clone(), node_id);
                     if let Err(e) = send_result {
-                        debug!(target: "consensus", "Error sending consensus message to peer - caching message {:?}: {:?}", node_id, e);
+                        debug!(target: "consensus", "Error sending consensus message to peer {node_id} caching message {}: {:?}", node_id, e);
                         // If we failed to send the message, cache it for later
                         let mut lock = self.eth_handler.message_cache.write();
                         lock.entry(Some(node_id.clone())).or_default().push(ChainMessageType::Consensus(block, message));

--- a/crates/net/network-devp2p/src/session_container.rs
+++ b/crates/net/network-devp2p/src/session_container.rs
@@ -202,7 +202,11 @@ impl SessionContainer {
                             // we got already got a session for the specified node.
                             // maybe the old session is already scheduled for getting deleted.
                             if !session.expired() {
-                                return Err(ErrorKind::AlreadyExists.into());
+                                return Err(ErrorKind::AlreadyExists(
+                                    *node_id,
+                                    existing_peer_id.clone(),
+                                )
+                                .into());
                             }
                         } else {
                             error!(target: "network", "host cache inconsistency: Session node id mismatch. expected: {} is {}.", existing_peer_id, id_from_session);

--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -161,9 +161,9 @@ error_chain! {
         }
 
         #[doc = "A connection to the specified nodeId already exists."]
-        AlreadyExists {
-            description("A connection to the specified nodeId already exists."),
-            display("A connection to the specified nodeId already exists."),
+        AlreadyExists(node_id: crate::NodeId, existing_peer_id: usize) {
+            description("A connection to specified node already exists."),
+            display("A connection to {} already exists. PeerID: {}", node_id, existing_peer_id),
         }
 
         #[doc = "Reached maximum connections"]


### PR DESCRIPTION
This pull request primarily improves code clarity and maintainability in the consensus and mining components by adding explanatory comments, refining log messages, and removing unused or obsolete code paths. The changes help document tricky edge cases, clarify logging output, and streamline the engine's update process.

**Comments and Documentation Improvements:**

* Added detailed comments in `TransactionQueue::pending` and `HoneyBadgerBFT::propose_block` to explain potential race conditions where the transaction pool cache may be stale after block import, and to clarify the implications of transaction pool maintenance timing. [[1]](diffhunk://#diff-0eb431e5ed185108a9fd210c09e62210a59a12cecabced517dc0ac17dda43495R478-R484) [[2]](diffhunk://#diff-a850cb878549a522cea1c384813a533d5cf74ce479af4cf4e3abbb3981fdea9cR1085-R1101)

**Logging Enhancements:**

* Improved log message in `HbbftEarlyEpochEndManager` to more clearly state why early epoch end reports are skipped, now referencing elapsed time since the last block rather than ambiguous timestamps.
* Changed a log level from `info!` to `debug!` in `EthSync` for errors encountered while sending consensus messages, reducing unnecessary log noise and clarifying the node context.

**Code Cleanup and Refactoring:**

* Removed an unused block of code in `HoneyBadgerBFT::set_signer` that previously attempted to update the HoneyBadger state and log issues if the client was not yet set, simplifying the signer update logic.